### PR TITLE
fix ssh_operator default value

### DIFF
--- a/airflow/contrib/operators/ssh_operator.py
+++ b/airflow/contrib/operators/ssh_operator.py
@@ -80,7 +80,11 @@ class SSHOperator(BaseOperator):
         self.timeout = timeout
         self.environment = environment
         self.do_xcom_push = do_xcom_push
-        self.get_pty = self.command.startswith('sudo') or get_pty
+        
+        if self.command:
+            self.get_pty = self.command.startswith('sudo') or get_pty
+        else:
+            self.get_pty = get_pty
 
     def execute(self, context):
         try:


### PR DESCRIPTION
[AIRFLOW-6402] https://issues.apache.org/jira/browse/AIRFLOW-6402
Fix for ssh operator default value.
Right now I am getting Nonetype Exception (1.10.7)